### PR TITLE
Show specific article

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -10,5 +10,11 @@ class Api::ArticlesController < ApplicationController
   
   def show
     article = Article.find(params[:id])
+    binding.pry
+    if article.empty?
+      render json: {error_message: "Article doesn't exist"}, status: 404
+    else
+      render json: {id: article.id, title: article.title, teaser: article.teaser, content: article.content}, status: 200
+    end
   end
 end

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -11,7 +11,7 @@ class Api::ArticlesController < ApplicationController
   def show
     article = Article.find(params[:id]) rescue nil
     if article.nil?
-      render json: { message: "Sorry your article wasn't found"}, status: 404 
+      render json: { message: "Sorry your article wasn't found" }, status: 404 
     else
       render json: article, status: 200
     end

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -9,9 +9,9 @@ class Api::ArticlesController < ApplicationController
   end
 
   def show
-    article = Article.find(params[:id])
+    article = Article.find(params[:id]) rescue nil
     if article.nil?
-      render json: { error_message: "Article doesn't exist" }, status: 404
+      render json: { message: "Sorry your article wasn't found"}, status: 404 
     else
       render json: article, status: 200
     end

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -1,19 +1,19 @@
 class Api::ArticlesController < ApplicationController
   def index
     collection_articles = Article.all
-     if collection_articles.empty?
-      render json: { error_message: "No articles has been found" }, status: 404
-     else
+    if collection_articles.empty?
+      render json: { error_message: 'No articles has been found' }, status: 404
+    else
       render json: { articles: collection_articles }, status: 200
-    end
+   end
   end
-  
+
   def show
     article = Article.find(params[:id])
     if article.nil?
-      render json: {error_message: "Article doesn't exist"}, status: 404
+      render json: { error_message: "Article doesn't exist" }, status: 404
     else
-      render json: {id: article.id, title: article.title, teaser: article.teaser, content: article.content}, status: 200
+      render json: article, status: 200
     end
   end
 end

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -10,8 +10,7 @@ class Api::ArticlesController < ApplicationController
   
   def show
     article = Article.find(params[:id])
-    binding.pry
-    if article.empty?
+    if article.nil?
       render json: {error_message: "Article doesn't exist"}, status: 404
     else
       render json: {id: article.id, title: article.title, teaser: article.teaser, content: article.content}, status: 200

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -7,4 +7,8 @@ class Api::ArticlesController < ApplicationController
       render json: { articles: collection_articles }, status: 200
     end
   end
+  
+  def show
+    article = Article.find(params[:id])
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  namespace :api do 
-   resources :articles, only: [:index, :show], constraints: { format: 'json' }
+  namespace :api do
+    resources :articles, only: %i[index show], constraints: { format: 'json' }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  namespace :api do
-    resources :articles, only: [:index], constraints: { format: 'json' }
+  namespace :api do 
+   resources :articles, only: [:index, :show], constraints: { format: 'json' }
   end
 end

--- a/spec/controllers/user_can_see_a_specific_article_spec.rb
+++ b/spec/controllers/user_can_see_a_specific_article_spec.rb
@@ -1,23 +1,18 @@
-require 'rails_helper'
-require 'factory_bot'
+# frozen_string_literal: true
+
 RSpec.describe 'Get/api/articles/', type: :request do
-    let!(:articles){create(:article, title: "coronavirus", teaser: "The World goverments cannot manage it", content: "it's spreading all around the world")}
-    let!(:articles){create(:article, title: "coronavirus 1", teaser: "The World goverments cannot at all manage it", content: "it's spreading all around the world like fire")}
-
-    describe 'GET/articles' do
-        # create(:article, title: 'A breaking news item', content: 'Some random content')
-        # create(:article, title: 'Some really breaking action', content: 'Some random content')
-        # @article = Article.new(title: "Corona is viral", teaser: "Is there something you can do?", content: "NO. sorry there isn't.")
-        # @article = Article.new(title: "Corona is killing", teaser: "Is there something you cannot do?", content: "NO. please,sorry there isn't.")
-
-            before do
-        get '/api/articles/2'
-        end
+  describe 'GET/articles' do
+    @article = Article.create(title: "Corona is viral", 
+        teaser: "Is there something you can do?", content: "NO. sorry there isn't.")
+    @article = Article.create(title: "Corona is defeated!!", 
+        teaser: "We are saved?", content: "NO! Recession is coming next!")
+        
+    before do
+      get '/api/articles/2'
+    end
 
     it 'should return a 200 response' do
-        expect(response.status).to eq 200
+      expect(response.status).to eq 200
     end
- end
+  end
 end
-
-

--- a/spec/controllers/user_can_see_a_specific_article_spec.rb
+++ b/spec/controllers/user_can_see_a_specific_article_spec.rb
@@ -1,43 +1,22 @@
 RSpec.describe 'Get/api/articles/', type: :request do
   describe 'GET/articles' do
-    @article = Article.create(title: "Corona is viral", 
-        teaser: "Is there something you can do?", content: "NO. sorry there isn't.")
-    @article = Article.create(title: "Corona is defeated!!", 
-        teaser: "We are saved?", content: "NO! Recession is coming next!")
-        
     before do
-      # create(:article, title: "coronavirus", teaser: "The World goverments cannot manage it", content: "it's spreading all around the world")
-      get '/api/articles/2'
+      @article = FactoryBot.create(:article, title: 'Corona is viral', teaser: 'Is there something you can do?', content: "NO. sorry there isn't.")
+      get "/api/articles/#{@article.id}"
     end
 
-    it 'should return a 200 response' do
+    it 'should return a valid article response' do
       expect(response.status).to eq 200
-    end
-
-    it 'should return id 2' do
-      expect((response_json)["id"]).to eq 2
-    end
-
-    it 'should return valid title' do
-      expect((response_json)["title"]).to eq "Corona is defeated!!"
-    end
-
-    it 'should return valid teaser' do
-      expect((response_json)["teaser"]).to eq "We are saved?"
-    end
-
-    it 'should return valid teaser' do
-      expect((response_json)["content"]).to eq "NO! Recession is coming next!"
+      expect(response_json['id']).to eq @article.id
+      expect(response_json['title']).to eq @article.title
+      expect(response_json['teaser']).to eq @article.teaser
+      expect(response_json['content']).to eq @article.content
     end
   end
 
   describe 'GET/articles [sad path]' do
-    before do
-      get '/api/articles/10000000'
-    end
-
     it 'should return a 404 response' do
-      binding.pry
+      get '/api/articles/2'
       expect(response.status).to eq 404
     end
   end

--- a/spec/controllers/user_can_see_a_specific_article_spec.rb
+++ b/spec/controllers/user_can_see_a_specific_article_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+require 'factory_bot'
+RSpec.describe 'Get/api/articles/', type: :request do
+    let!(:articles){create(:article, title: "coronavirus", teaser: "The World goverments cannot manage it", content: "it's spreading all around the world")}
+    let!(:articles){create(:article, title: "coronavirus 1", teaser: "The World goverments cannot at all manage it", content: "it's spreading all around the world like fire")}
+
+    describe 'GET/articles' do
+        # create(:article, title: 'A breaking news item', content: 'Some random content')
+        # create(:article, title: 'Some really breaking action', content: 'Some random content')
+        # @article = Article.new(title: "Corona is viral", teaser: "Is there something you can do?", content: "NO. sorry there isn't.")
+        # @article = Article.new(title: "Corona is killing", teaser: "Is there something you cannot do?", content: "NO. please,sorry there isn't.")
+
+            before do
+        get '/api/articles/2'
+        end
+
+    it 'should return a 200 response' do
+        expect(response.status).to eq 200
+    end
+ end
+end
+
+

--- a/spec/controllers/user_can_see_a_specific_article_spec.rb
+++ b/spec/controllers/user_can_see_a_specific_article_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe 'Get/api/articles/', type: :request do
   describe 'GET/articles' do
     @article = Article.create(title: "Corona is viral", 
@@ -8,25 +6,39 @@ RSpec.describe 'Get/api/articles/', type: :request do
         teaser: "We are saved?", content: "NO! Recession is coming next!")
         
     before do
+      # create(:article, title: "coronavirus", teaser: "The World goverments cannot manage it", content: "it's spreading all around the world")
       get '/api/articles/2'
     end
 
     it 'should return a 200 response' do
       expect(response.status).to eq 200
+    end
+
+    it 'should return id 2' do
+      expect((response_json)["id"]).to eq 2
+    end
+
+    it 'should return valid title' do
+      expect((response_json)["title"]).to eq "Corona is defeated!!"
+    end
+
+    it 'should return valid teaser' do
+      expect((response_json)["teaser"]).to eq "We are saved?"
+    end
+
+    it 'should return valid teaser' do
+      expect((response_json)["content"]).to eq "NO! Recession is coming next!"
+    end
+  end
+
+  describe 'GET/articles [sad path]' do
+    before do
+      get '/api/articles/10000000'
+    end
+
+    it 'should return a 404 response' do
       binding.pry
+      expect(response.status).to eq 404
     end
-
-    it 'should return a 200 response' do
-      expect(response.id).to eq 200
-    end
-
-    it 'should return a 200 response' do
-      expect(response.title).to eq 200
-    end
-
-    it 'should return a 200 response' do
-      expect(response.title).to eq 200
-    end
-
   end
 end

--- a/spec/controllers/user_can_see_a_specific_article_spec.rb
+++ b/spec/controllers/user_can_see_a_specific_article_spec.rb
@@ -13,6 +13,20 @@ RSpec.describe 'Get/api/articles/', type: :request do
 
     it 'should return a 200 response' do
       expect(response.status).to eq 200
+      binding.pry
     end
+
+    it 'should return a 200 response' do
+      expect(response.id).to eq 200
+    end
+
+    it 'should return a 200 response' do
+      expect(response.title).to eq 200
+    end
+
+    it 'should return a 200 response' do
+      expect(response.title).to eq 200
+    end
+
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,3 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
 end
-
-
-  


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171841408)
```
As a Visitor
In order to read an article
I would like to be able to click on an article and have it displayed
```
## Changes proposed in this pull request:
* Request spec for specific article 
* Show method in controller
* Route for show method
## What I have learned working on this feature:
* Using FactoryBot to create articles
* To use the rescue when API calls are failing