### PR TITLE
API provides functionality for labeling articles as premium/not premium

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -20,7 +20,7 @@ class Api::ArticlesController < ApplicationController
     if article.persisted?
       render json: { message: 'Your article is ready for review.' }, status: 200
     else
-      render json: { message: 'Your article was not saved.' }, status: 206
+      render json: { message: 'Your article was not saved.' }, status: 406
     end
   end
 

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -27,6 +27,6 @@ class Api::ArticlesController < ApplicationController
   private
 
   def article_params
-    params.require(:article).permit(:title, :teaser, :content)
+    params.require(:article).permit(:title, :teaser, :content, :premium_article)
   end
 end

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -27,6 +27,6 @@ class Api::ArticlesController < ApplicationController
   private
 
   def article_params
-    params.require(:article).permit(:title, :teaser, :content, :premium_article)
+    params.require(:article).permit(:title, :teaser, :content, :article_class)
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,3 +1,4 @@
 class Article < ApplicationRecord
-  validates_presence_of :title, :teaser, :content, :premium_article
+  validates_presence_of :title, :teaser, :content, :article_class
+  enum article_class: [:free, :premium]
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,3 +1,3 @@
 class Article < ApplicationRecord
-  validates_presence_of :title, :teaser, :content
+  validates_presence_of :title, :teaser, :content, :premium_article
 end

--- a/db/migrate/20200324131210_add_premium_article_to_article.rb
+++ b/db/migrate/20200324131210_add_premium_article_to_article.rb
@@ -1,5 +1,5 @@
 class AddPremiumArticleToArticle < ActiveRecord::Migration[6.0]
   def change
-    add_column :articles, :premium_article, :boolean
+    add_column :articles, :article_class, :integer, :default => 0
   end
 end

--- a/db/migrate/20200324131210_add_premium_article_to_article.rb
+++ b/db/migrate/20200324131210_add_premium_article_to_article.rb
@@ -1,0 +1,5 @@
+class AddPremiumArticleToArticle < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :premium_article, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 2020_03_24_131210) do
     t.text "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "premium_article"
+    t.integer "article_class", default: 0
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_19_134722) do
+ActiveRecord::Schema.define(version: 2020_03_24_131210) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_03_19_134722) do
     t.text "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "premium_article"
   end
 
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     title { "CoronaVirus" }
     teaser { "Sweden is free of Coronavirus" }
     content { "blahblahblha blahblah blah" }
+    premium_article { true }
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     title { "CoronaVirus" }
     teaser { "Sweden is free of Coronavirus" }
     content { "blahblahblha blahblah blah" }
-    premium_article { true }
+    article_class { 0 }
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_db_column :teaser }
     it { is_expected.to have_db_column :content }
     it { is_expected.to have_db_column :article_class }
-    
   end
 
   describe 'Validations' do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -10,11 +10,14 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_db_column :title }
     it { is_expected.to have_db_column :teaser }
     it { is_expected.to have_db_column :content }
+    it { is_expected.to have_db_column :premium_article }
+    
   end
 
   describe 'Validations' do
     it { is_expected.to validate_presence_of :title}
     it { is_expected.to validate_presence_of :teaser }
-    it { is_expected.to validate_presence_of :content } 
+    it { is_expected.to validate_presence_of :content}
+    it { is_expected.to validate_presence_of :premium_article } 
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_db_column :title }
     it { is_expected.to have_db_column :teaser }
     it { is_expected.to have_db_column :content }
-    it { is_expected.to have_db_column :premium_article }
+    it { is_expected.to have_db_column :article_class }
     
   end
 
@@ -18,6 +18,6 @@ RSpec.describe Article, type: :model do
     it { is_expected.to validate_presence_of :title}
     it { is_expected.to validate_presence_of :teaser }
     it { is_expected.to validate_presence_of :content}
-    it { is_expected.to validate_presence_of :premium_article } 
+    it { is_expected.to validate_presence_of :article_class } 
   end
 end

--- a/spec/requests/api/journalist_can_create_article_spec.rb
+++ b/spec/requests/api/journalist_can_create_article_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Api::ArticlesController, type: :request do
              title: 'Coronavirus',
              teaser: 'Things are bad',
              content: 'It will get worse.',
-             premium_article: true
+             premium_article: 0
              }
            },
            headers: headers
@@ -35,14 +35,14 @@ RSpec.describe Api::ArticlesController, type: :request do
             title: 'Coronavirus',
             teaser: 'Things are bad',
             content: '',
-            premium_article: true
+            premium_article: 1
             }
           },
           headers: headers
     end
     
     it 'returns a 206 response status' do
-      expect(response.status).to eq 206
+      expect(response.status).to eq 406
     end
 
     it 'does not create an Article entry' do

--- a/spec/requests/api/journalist_can_create_article_spec.rb
+++ b/spec/requests/api/journalist_can_create_article_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Api::ArticlesController, type: :request do
              article: {
              title: 'Coronavirus',
              teaser: 'Things are bad',
-             content: 'It will get worse.'
+             content: 'It will get worse.',
+             premium_article: true
              }
            },
            headers: headers
@@ -23,6 +24,29 @@ RSpec.describe Api::ArticlesController, type: :request do
     it 'succesfully creates Article entry' do
       entry = Article.last
       expect(entry.title).to eq 'Coronavirus'
+    end
+  end
+
+    describe '[Sad path] POST /api/articles_controller' do
+      before do
+        post '/api/articles',
+          params: {
+            article: {
+            title: 'Coronavirus',
+            teaser: 'Things are bad',
+            content: '',
+            premium_article: true
+            }
+          },
+          headers: headers
+    end
+    
+    it 'returns a 206 response status' do
+      expect(response.status).to eq 206
+    end
+
+    it 'does not create an Article entry' do
+      expect(response_json["message"]).to eq 'Your article was not saved.'
     end
   end
 end

--- a/spec/requests/api/journalist_can_create_article_spec.rb
+++ b/spec/requests/api/journalist_can_create_article_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Api::ArticlesController, type: :request do
              title: 'Coronavirus',
              teaser: 'Things are bad',
              content: 'It will get worse.',
-             premium_article: 0
+             article_class: 0
              }
            },
            headers: headers
@@ -35,13 +35,13 @@ RSpec.describe Api::ArticlesController, type: :request do
             title: 'Coronavirus',
             teaser: 'Things are bad',
             content: '',
-            premium_article: 1
+            article_class: 1
             }
           },
           headers: headers
     end
     
-    it 'returns a 206 response status' do
+    it 'returns a 406 response status' do
       expect(response.status).to eq 406
     end
 

--- a/spec/requests/api/journalist_can_create_article_spec.rb
+++ b/spec/requests/api/journalist_can_create_article_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Api::ArticlesController, type: :request do
              title: 'Coronavirus',
              teaser: 'Things are bad',
              content: 'It will get worse.',
-             article_class: 0
+             article_class: "free"
              }
            },
            headers: headers
@@ -35,7 +35,7 @@ RSpec.describe Api::ArticlesController, type: :request do
             title: 'Coronavirus',
             teaser: 'Things are bad',
             content: '',
-            article_class: 1
+            article_class: "premium"
             }
           },
           headers: headers


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171833958)
```
As a Stakeholder
In order to restrict certain content
I would like to provide the functionality of labeling content as Premium or Non-premium
```
## Changes proposed in this pull request:
* New db column for article called article_class
* Enum to label articles as :free and :premium
* Adding new article param in create method in ArticlesController

## What I have learned working on this feature:
* Generate migrations through command line
* Enum repetition