### PR TITLE
Geolocation session

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rack-cors', require: 'rack/cors'
 gem 'devise_token_auth'
 gem 'stripe-rails'
+gem 'geocoder'
 
 group :development, :test do
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
     ffi (1.12.2)
+    geocoder (1.6.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.8.2)
@@ -235,6 +236,7 @@ DEPENDENCIES
   coveralls
   devise_token_auth
   factory_bot_rails
+  geocoder
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry-byebug

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -3,7 +3,7 @@ class Api::SessionsController < ApplicationController
     lat = params[:location][:latitude].to_f
     long = params[:location][:longitude].to_f
     results = Geocoder.search([lat, long])
-    edition = (results.first.county.match? /Västerås kommun|Stockholm County/) ? results.first.county : "Global"
+    edition = (results.first.county.match? /Västerås kommun|Stockholms kommun/) ? results.first.county : "Global"
     render json: {
       session: {
         location: {

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -1,0 +1,10 @@
+class Api::SessionsController < ApplicationController
+  def create
+    render json: { session: 
+    { location:
+      { latitude: params[:location][:latitude].to_f,
+        longitude: params[:location][:longitude].to_f},
+      edition: "Västerås"}
+    }
+  end
+end

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -1,9 +1,10 @@
 class Api::SessionsController < ApplicationController
   def create
+    binding.pry
     lat = params[:location][:latitude].to_f
     long = params[:location][:longitude].to_f
     results = Geocoder.search([lat, long])
-    edition = (results.first.county.match(/Västerås kommun|King County/)) ? results.first.county : "Global"
+    edition = (results.first.county.match? /Västerås kommun|Stockholm County/) ? results.first.county : "Global"
     render json: {
       session: {
         location: {

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -1,10 +1,14 @@
 class Api::SessionsController < ApplicationController
   def create
+    lat = params[:location][:latitude].to_f
+    long = params[:location][:longitude].to_f
+    results = Geocoder.search([lat, long])
+    edition = (results.first.county.match? /Västerås kommun|King County/) ? results.first.county : "Global"
     render json: { session: 
     { location:
-      { latitude: params[:location][:latitude].to_f,
-        longitude: params[:location][:longitude].to_f},
-      edition: "Västerås"}
+      { latitude: lat,
+        longitude: long},
+      edition: edition}
     }
   end
 end

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -3,12 +3,15 @@ class Api::SessionsController < ApplicationController
     lat = params[:location][:latitude].to_f
     long = params[:location][:longitude].to_f
     results = Geocoder.search([lat, long])
-    edition = (results.first.county.match? /Västerås kommun|King County/) ? results.first.county : "Global"
-    render json: { session: 
-    { location:
-      { latitude: lat,
-        longitude: long},
-      edition: edition}
+    edition = (results.first.county.match(/Västerås kommun|King County/)) ? results.first.county : "Global"
+    render json: {
+      session: {
+        location: {
+          latitude: lat,
+          longitude: long
+        },
+          edition: edition 
+      } 
     }
   end
 end

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -1,6 +1,5 @@
 class Api::SessionsController < ApplicationController
   def create
-    binding.pry
     lat = params[:location][:latitude].to_f
     long = params[:location][:longitude].to_f
     results = Geocoder.search([lat, long])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,6 @@ Rails.application.routes.draw do
   namespace :api do
     resources :articles, only: %i[index show create], constraints: { format: 'json' }
     resources :subscriptions, only: [ :create ], constraints: { format: 'json' } 
+    resources :sessions, only: [ :create ], constraints: { format: 'json' }
   end
 end

--- a/spec/requests/api/visitor_can_see_name_of_edition_spec.rb
+++ b/spec/requests/api/visitor_can_see_name_of_edition_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe Api::SessionsController, type: :request do
 
     it ' returns a "session" object with location and edition name Stockholm' do
       post "/api/sessions", params: { location: {latitude: 59.31, longitude: 18.07 }}
-      binding.pry
-      expect(response_json["session"]["edition"]).to eq "Stockholm kommun"
+      expect(response_json["session"]["edition"]).to eq "Stockholms kommun"
     end
   end
 end

--- a/spec/requests/api/visitor_can_see_name_of_edition_spec.rb
+++ b/spec/requests/api/visitor_can_see_name_of_edition_spec.rb
@@ -1,14 +1,19 @@
 RSpec.describe Api::SessionsController, type: :request do
   describe "POST api/sessions" do
 
-    it ' returns a "session" object with location and edition name for Västerås' do
-      post "/api/sessions", params: { location: {latitude: 59.60, longitude: 16.55 }}
-      expect(response_json["session"]["edition"]).to eq "Västerås"
+    it ' returns a "session" object with location and edition name for outside Västerås and Seattle' do
+      post "/api/sessions", params: { location: {latitude: 48.85, longitude: 2.35 }}
+      expect(response_json["session"]["edition"]).to eq "Global"
+    end
+
+    it ' returns a "session" object with location and edition name for Västerås kommun' do
+      post "/api/sessions", params: { location: {latitude: 59.59, longitude: 16.67 }}
+      expect(response_json["session"]["edition"]).to eq "Västerås kommun"
     end
 
     it ' returns a "session" object with location and edition name Seattle' do
       post "/api/sessions", params: { location: {latitude: 47.60, longitude: -122.33 }}
-      expect(response_json["session"]["edition"]).to eq "Seattle"
+      expect(response_json["session"]["edition"]).to eq "King County"
     end
   end
 end

--- a/spec/requests/api/visitor_can_see_name_of_edition_spec.rb
+++ b/spec/requests/api/visitor_can_see_name_of_edition_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe Api::SessionsController, type: :request do
       expect(response_json["session"]["edition"]).to eq "Västerås kommun"
     end
 
-    it ' returns a "session" object with location and edition name Seattle' do
-      post "/api/sessions", params: { location: {latitude: 47.60, longitude: -122.33 }}
-      expect(response_json["session"]["edition"]).to eq "King County"
+    it ' returns a "session" object with location and edition name Stockholm' do
+      post "/api/sessions", params: { location: {latitude: 59.31, longitude: 18.07 }}
+      binding.pry
+      expect(response_json["session"]["edition"]).to eq "Stockholm kommun"
     end
   end
 end

--- a/spec/requests/api/visitor_can_see_name_of_edition_spec.rb
+++ b/spec/requests/api/visitor_can_see_name_of_edition_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe Api::SessionsController, type: :request do
+  describe "POST api/sessions" do
+
+    it ' returns a "session" object with location and edition name for Västerås' do
+      post "/api/sessions", params: { location: {latitude: 59.60, longitude: 16.55 }}
+      expect(response_json["session"]["edition"]).to eq "Västerås"
+    end
+
+    it ' returns a "session" object with location and edition name Seattle' do
+      post "/api/sessions", params: { location: {latitude: 47.60, longitude: -122.33 }}
+      expect(response_json["session"]["edition"]).to eq "Seattle"
+    end
+  end
+end


### PR DESCRIPTION
# [PT link](https://www.pivotaltracker.com/story/show/172122263)
## User Story
```
As a user
In order to read relevant articles close to my location
I would like to see relevant articles to be based on my location.
```
## Changes proposed in this pull request:
* Adds sessions controller
* Refactors code in sessions controller

## What I have learned working on this feature:
* Positions can't be transmitted as a whole, they need to be broken down into long/lat
* Repetition is golden

## Packages/Gems added
- GeoCoder